### PR TITLE
fix training without a network pkl passed from command line

### DIFF
--- a/GAN_cpd/train.py
+++ b/GAN_cpd/train.py
@@ -165,7 +165,7 @@ def train_progressive_gan(
 
     # Construct networks.
     with tf.device('/gpu:0'):
-        if resume_run_id is not None:
+        if resume_run_id != "None":
             network_pkl = misc.locate_network_pkl(resume_run_id, resume_snapshot)
             print('Loading networks from "%s"...' % network_pkl, flush=True)
             G, D, Gs = misc.load_pkl(network_pkl)


### PR DESCRIPTION
The network pkl argument is a string type when passed from command line, and will therefore not evaluate to None if set to "None".